### PR TITLE
Refactor migrations so they can be used on an empty db

### DIFF
--- a/server-extension/src/main/java/flyway/asdistats/V1_2__add_permission_for_regionset.java
+++ b/server-extension/src/main/java/flyway/asdistats/V1_2__add_permission_for_regionset.java
@@ -2,7 +2,8 @@ package flyway.asdistats;
 
 import fi.nls.oskari.domain.Role;
 import fi.nls.oskari.domain.User;
-import fi.nls.oskari.domain.map.OskariLayer;
+import fi.nls.oskari.map.layer.OskariLayerService;
+import fi.nls.oskari.service.OskariComponentManager;
 import fi.nls.oskari.service.ServiceException;
 import fi.nls.oskari.service.ServiceRuntimeException;
 import fi.nls.oskari.service.UserService;
@@ -16,6 +17,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * Add permissions for regionset: countries
@@ -46,8 +48,14 @@ public class V1_2__add_permission_for_regionset implements JdbcMigration {
 
     // statslayers described as layer resources for permissions handling
     protected List<Resource> getResources() {
-        List<Resource> list = new ArrayList<>();
-        list.add(new OskariLayerResource(OskariLayer.TYPE_STATS, "resources://regionsets/ne_110m_countries-3575.json", "ne_110m_countries-3575"));
+        List<Resource> list = OskariComponentManager.getComponentOfType(OskariLayerService.class)
+                .findByUrlAndName("resources://regionsets/ne_110m_countries-3575.json", "ne_110m_countries-3575")
+                .stream().map(l -> {
+                    Resource res = new Resource();
+                    res.setType(ResourceType.maplayer);
+                    res.setMapping(Integer.toString(l.getId()));
+                    return res;
+                }).collect(Collectors.toList());
         return list;
     }
 

--- a/server-extension/src/main/java/flyway/asdistats/V1_4__add_permission_for_protected_areas_regionset.java
+++ b/server-extension/src/main/java/flyway/asdistats/V1_4__add_permission_for_protected_areas_regionset.java
@@ -1,11 +1,12 @@
 package flyway.asdistats;
 
-import fi.nls.oskari.domain.map.OskariLayer;
-import org.oskari.permissions.model.OskariLayerResource;
+import fi.nls.oskari.map.layer.OskariLayerService;
+import fi.nls.oskari.service.OskariComponentManager;
 import org.oskari.permissions.model.Resource;
+import org.oskari.permissions.model.ResourceType;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Add permissions for regionset: protected areas
@@ -14,8 +15,14 @@ public class V1_4__add_permission_for_protected_areas_regionset extends V1_2__ad
 
     // statslayers described as layer resources for permissions handling
     protected List<Resource> getResources() {
-        List<Resource> list = new ArrayList<>();
-        list.add(new OskariLayerResource(OskariLayer.TYPE_STATS, "resources://regionsets/protectedareas-3575.json", "protectedareas-3575"));
+        List<Resource> list = OskariComponentManager.getComponentOfType(OskariLayerService.class)
+                .findByUrlAndName("resources://regionsets/protectedareas-3575.json", "protectedareas-3575")
+                .stream().map(l -> {
+                    Resource res = new Resource();
+                    res.setType(ResourceType.maplayer);
+                    res.setMapping(Integer.toString(l.getId()));
+                    return res;
+                }).collect(Collectors.toList());
         return list;
     }
 }


### PR DESCRIPTION
Permission mapping changed in Oskari 1.53 from type+url+name to layer id. Since production doesn't even have statistics functionality yet this fixes the Flyway module to work when we want to enable it on prod.