### PR TITLE
Revert "Add activation.jar to fix Java 11+ issue"

### DIFF
--- a/webapp-map/pom.xml
+++ b/webapp-map/pom.xml
@@ -87,11 +87,7 @@
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
         </dependency>
-        <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>activation</artifactId>
-            <version>1.1.1</version>
-        </dependency>
+
     </dependencies>
 
     <build>


### PR DESCRIPTION
Reverts arctic-sdi/oskari-server-extensions#24

It's not enough to package it on the app, it needs to be on the server classpath.